### PR TITLE
Bugfixes when converting non ASCII-chars and other

### DIFF
--- a/hex_to_ascii.py
+++ b/hex_to_ascii.py
@@ -11,24 +11,29 @@ class HexToAsciiCommand(sublime_plugin.TextCommand):
         for j in range(0, len(reglist)):
             hx = v.substr(v.sel()[j])
             hx = hx.strip('{} .,')
-            if ',' in hx:
-                hx = hx.replace(', ', ' ')
-                hx = hx.replace(',', ' ')
-            if '0x' in hx:
-                hx = hx.replace('0x', '')
-            astr = ''
-            if ' ' in hx:
-                t = 1
-            else:
-                t = 2
-            if (len(hx) % 2 != 0) and (t == 2):
+            
+            for i in ('0x', '\n', '\r', ',', ', '):
+                hx = hx.replace(i, '')
+
+            if (len(hx) % 2 != 0):
                 sublime.status_message("Perhaps we lost key \"%s\" in the end of line?" % hx[len(hx) - 1])
-            for i in range(0, len(hx)-1, t):
+
+            astr = u''
+
+            for i in range(0, len(hx)-1, 2):
                 if not(hx[i] in hexdig) or not(hx[i+1] in hexdig):
                     sublime.error_message("\"%s\" isn't a part of hexadecimal number!" % hx[i:i+2])
                     break
                 if (hx[i] == ' ') or (hx[i+1] == ' '):
                     continue
+                
                 st = hx[i]+hx[i+1]
-                astr = astr + chr(int(st, 16))
+                code = int(st, 16)
+
+                if code > 128:
+                    astr += '?'
+                else:
+                    astr += unichr(code)
+                    
+                print st, '->', astr
                 v.replace(edit, v.sel()[j], astr)


### PR DESCRIPTION
- fixed crash when converting non ASCII-chars. These chars will be displayed as '?'
- longer hex-values can be converted e.g. 0x48616c6c6f to >>Hallo<<
- mulitline hex-values can be converted e.g. 0x68656c6c6f,\n0x206d617465 to >>hello mate<<